### PR TITLE
urls to ajax.php should contain "NOAUTH"

### DIFF
--- a/PubmedSearchExternalModule.php
+++ b/PubmedSearchExternalModule.php
@@ -403,7 +403,6 @@ class PubmedSearchExternalModule extends AbstractExternalModule
 	public function loadSettings($instrument) {
 		$set = $this->getProjectSettings();
 		$set['module-path'] = $this->getPostURL();
-		$set['test-path'] = $this->getTestURL();
 		$set['record_id'] = $this->getRecordId();
 		$this->settings[] = $set;
 	}
@@ -484,13 +483,6 @@ class PubmedSearchExternalModule extends AbstractExternalModule
 	}
 
 	public function getPostURL(){
-		return $this->getUrl("ajax.php", false, false);
-		// return $this->getUrl("PubmedSearchExternalModule.php", false, false);
-		// return $this->getModulePath();
-	}
-	public function getTestURL(){
-		return $this->getUrl("test.xml", false, false);
-		// return $this->getUrl("PubmedSearchExternalModule.php", false, false);
-		// return $this->getModulePath();
+		return $this->getUrl("ajax.php", true, false);
 	}
 }

--- a/ajax.php
+++ b/ajax.php
@@ -5,14 +5,11 @@ global $module;
 * @var $module \Vanderbilt\PubmedSearchExternalModule
 */
 include_once('PubmedSearchExternalModule.php');
-// use Vanderbilt\PubmedSearchExternalModule;
-// Get value of clicked button
 
 $post_data = json_decode( file_get_contents( 'php://input' ), true );
 
 $pid = $module->framework->getProjectId();
 $json_pubmeds = $module->pubmedRun($pid, $post_data);
 
-// echo json_encode($json_pubmeds);
 print_r($json_pubmeds);
 ?>

--- a/config.json
+++ b/config.json
@@ -36,16 +36,6 @@
 
 	"no-auth-pages":["ajax"],
 
-	"links": {
-		"project": [
-			{
-				"name": "Test Pubmedsearch",
-				"icon": "report",
-				"url": "ajax.php"
-			}
-		]
-	},
-
 	"system-settings": [
 		{
 			"key": "enable-system-debug-logging",


### PR DESCRIPTION
small change to allow fetching publications from a public survey without auth
also removes test links

sorry to bug you again @scottjpearson
btw Flight Tracker is epic! I'm presenting that to our leadership and hope it gains traction